### PR TITLE
feat: Add callback management feature to the Visual Builder

### DIFF
--- a/src/app/components/builder-tabs/builder-tabs.component.html
+++ b/src/app/components/builder-tabs/builder-tabs.component.html
@@ -160,6 +160,55 @@
           }
         </div>
       </mat-tab>
+      <mat-tab class="tabs-header">
+        <ng-template mat-tab-label>
+          <span class="tab-label">Callbacks</span>
+        </ng-template>
+        <div class="tab-content-container">
+          @if (editingCallback) {
+            <button mat-icon-button (click)="backToCallbackList()" class="back-button">
+              <mat-icon>arrow_back</mat-icon>
+            </button>
+            <div class="config-form">
+              <mat-form-field class="callback-name-field">
+                <mat-label>Callback Name</mat-label>
+                <input matInput [(ngModel)]="editingCallback.name" />
+              </mat-form-field>
+              
+              <mat-form-field class="callback-type-field">
+                <mat-label>Callback Type</mat-label>
+                <mat-select [(ngModel)]="editingCallback.type" (selectionChange)="onCallbackTypeChange(editingCallback)">
+                  @for (type of callbackTypes; track type) {
+                    <mat-option [value]="type">{{type}}</mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+
+              <mat-form-field class="callback-description-field">
+                <mat-label>Description (Optional)</mat-label>
+                <input matInput [(ngModel)]="editingCallback.description" />
+              </mat-form-field>
+
+              <div class="callback-section">
+                <p class="callback-section-label">Python Code</p>
+                <mat-form-field class="callback-code-field">
+                  <textarea matInput rows="10" [(ngModel)]="editingCallback.code"></textarea>
+                </mat-form-field>
+              </div>
+            </div>
+          } @else {
+            @if (agentConfig && agentConfig.callbacks && agentConfig.callbacks.length > 0) {
+              <ul>
+                @for (callback of agentConfig.callbacks; track callback) {
+                  <li (click)="selectCallback(callback)" class="callback-name">{{callback.name}} ({{callback.type}})</li>
+                }
+              </ul>
+            } @else {
+              <span class="no-callbacks-message">This agent has no callbacks</span>
+            }
+          }
+        </div>
+      </mat-tab>
     </mat-tab-group>
   </div>
 </div>

--- a/src/app/components/builder-tabs/builder-tabs.component.scss
+++ b/src/app/components/builder-tabs/builder-tabs.component.scss
@@ -165,3 +165,32 @@
 .back-button {
   margin-bottom: 16px;
 }
+
+.no-callbacks-message {
+  color: #9aa0a6;
+  font-size: 16px;
+  margin-top: 16px;
+  text-align: center;
+}
+
+.callback-name {
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+}
+
+.callback-section {
+  margin-top: 16px;
+
+  .callback-section-label {
+    margin: 0 0 8px 0;
+    color: #9aa0a6;
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: none;
+  }
+}

--- a/src/app/components/builder-tabs/builder-tabs.component.spec.ts
+++ b/src/app/components/builder-tabs/builder-tabs.component.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChangeDetectorRef } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { BuilderTabsComponent } from './builder-tabs.component';
+import { AgentBuilderService } from '../../core/services/agent-builder.service';
+import { AgentNode, CallbackNode, ToolNode } from '../../core/models/AgentBuilder';
+
+describe('BuilderTabsComponent - Callback Support', () => {
+  let component: BuilderTabsComponent;
+  let fixture: ComponentFixture<BuilderTabsComponent>;
+  let mockAgentBuilderService: jasmine.SpyObj<AgentBuilderService>;
+  let mockChangeDetectorRef: jasmine.SpyObj<ChangeDetectorRef>;
+
+  beforeEach(async () => {
+    const agentBuilderServiceSpy = jasmine.createSpyObj('AgentBuilderService', [
+      'getSelectedNode',
+      'getSelectedTool', 
+      'getSelectedCallback',
+      'getAgentTools',
+      'getAgentCallbacks'
+    ]);
+
+    const changeDetectorRefSpy = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
+
+    await TestBed.configureTestingModule({
+      declarations: [BuilderTabsComponent],
+      providers: [
+        { provide: AgentBuilderService, useValue: agentBuilderServiceSpy },
+        { provide: ChangeDetectorRef, useValue: changeDetectorRefSpy }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BuilderTabsComponent);
+    component = fixture.componentInstance;
+    mockAgentBuilderService = TestBed.inject(AgentBuilderService) as jasmine.SpyObj<AgentBuilderService>;
+    mockChangeDetectorRef = TestBed.inject(ChangeDetectorRef) as jasmine.SpyObj<ChangeDetectorRef>;
+
+    // Setup default return values
+    mockAgentBuilderService.getSelectedNode.and.returnValue(new BehaviorSubject<AgentNode | undefined>(undefined));
+    mockAgentBuilderService.getSelectedTool.and.returnValue(new BehaviorSubject<ToolNode | undefined>(undefined));
+    mockAgentBuilderService.getSelectedCallback.and.returnValue(new BehaviorSubject<CallbackNode | undefined>(undefined));
+    mockAgentBuilderService.getAgentTools.and.returnValue(new BehaviorSubject<{ agentName: string, tools: ToolNode[] } | undefined>(undefined));
+    mockAgentBuilderService.getAgentCallbacks.and.returnValue(new BehaviorSubject<{ agentName: string, callbacks: CallbackNode[] } | undefined>(undefined));
+  });
+
+  describe('Callback Properties', () => {
+    it('should have callback-related properties', () => {
+      expect(component.editingCallback).toBeDefined();
+      expect(component.selectedCallback).toBeDefined();
+      expect(component.callbackTypes).toBeDefined();
+      expect(component.callbackTypes.length).toBe(6);
+      expect(component.callbackTypes).toContain('before_agent');
+      expect(component.callbackTypes).toContain('after_agent');
+      expect(component.callbackTypes).toContain('before_model');
+      expect(component.callbackTypes).toContain('after_model');
+      expect(component.callbackTypes).toContain('before_tool');
+      expect(component.callbackTypes).toContain('after_tool');
+    });
+  });
+
+  describe('Callback Methods', () => {
+    let mockCallback: CallbackNode;
+
+    beforeEach(() => {
+      mockCallback = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(ctx): pass',
+        description: 'Test callback'
+      };
+    });
+
+    it('should select callback correctly', () => {
+      component.selectCallback(mockCallback);
+      
+      expect(component.editingCallback).toBe(mockCallback);
+    });
+
+    it('should navigate back to callback list', () => {
+      component.editingCallback = mockCallback;
+      
+      component.backToCallbackList();
+      
+      expect(component.editingCallback).toBeNull();
+    });
+
+    it('should handle callback type change', () => {
+      const callback = { ...mockCallback };
+      
+      component.onCallbackTypeChange(callback);
+      
+      expect(callback.type).toBe('before_agent');
+    });
+  });
+
+  describe('Service Integration', () => {
+    it('should subscribe to selected callback changes', () => {
+      const callbackSubject = new BehaviorSubject<CallbackNode | undefined>(undefined);
+      mockAgentBuilderService.getSelectedCallback.and.returnValue(callbackSubject);
+      
+      const mockCallback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(ctx): pass'
+      };
+      
+      // Reinitialize component to trigger constructor
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      
+      callbackSubject.next(mockCallback);
+      
+      expect(component.selectedCallback).toBe(mockCallback);
+      expect(component.selectedTabIndex).toBe(3); // Callback tab index
+    });
+
+    it('should subscribe to agent callback updates', () => {
+      const callbacksSubject = new BehaviorSubject<{ agentName: string, callbacks: CallbackNode[] } | undefined>(undefined);
+      mockAgentBuilderService.getAgentCallbacks.and.returnValue(callbacksSubject);
+      
+      component.agentConfig = {
+        name: 'test-agent',
+        isRoot: true,
+        agent_class: 'LlmAgent',
+        model: 'gemini-2.5-flash',
+        instruction: 'test',
+        sub_agents: [],
+        tools: [],
+        callbacks: []
+      };
+      
+      const mockCallbacks: CallbackNode[] = [{
+        name: 'callback1',
+        type: 'before_agent',
+        code: 'def callback1(ctx): pass'
+      }];
+      
+      // Reinitialize component to trigger constructor
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      
+      callbacksSubject.next({ agentName: 'test-agent', callbacks: mockCallbacks });
+      
+      expect(component.agentConfig?.callbacks).toBe(mockCallbacks);
+    });
+  });
+
+  describe('Callback UI Behavior', () => {
+    it('should set selectedTabIndex to 3 when selecting a callback', () => {
+      const mockCallback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(ctx): pass'
+      };
+      
+      const callbackSubject = new BehaviorSubject<CallbackNode | undefined>(undefined);
+      mockAgentBuilderService.getSelectedCallback.and.returnValue(callbackSubject);
+      
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      callbackSubject.next(mockCallback);
+      
+      expect(component.selectedTabIndex).toBe(3);
+      expect(component.editingCallback).toBe(mockCallback);
+    });
+
+    it('should handle null callback selection', () => {
+      const callbackSubject = new BehaviorSubject<CallbackNode | undefined>(undefined);
+      mockAgentBuilderService.getSelectedCallback.and.returnValue(callbackSubject);
+      
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      component.editingCallback = { name: 'test', type: 'before_agent', code: '' };
+      
+      callbackSubject.next(undefined);
+      
+      expect(component.editingCallback).toBeNull();
+    });
+  });
+
+  describe('Callback Code Field', () => {
+    it('should initialize callback with empty code', () => {
+      const mockCallback: CallbackNode = {
+        name: 'new_callback',
+        type: 'before_agent',
+        code: ''
+      };
+      
+      component.selectCallback(mockCallback);
+      
+      expect(component.editingCallback?.code).toBe('');
+    });
+
+    it('should preserve callback code when editing', () => {
+      const customCode = 'def my_callback(ctx):\n    print("Custom callback")\n    return None';
+      const mockCallback: CallbackNode = {
+        name: 'custom_callback',
+        type: 'after_agent',
+        code: customCode
+      };
+      
+      component.selectCallback(mockCallback);
+      
+      expect(component.editingCallback?.code).toBe(customCode);
+    });
+
+    it('should handle callback with description', () => {
+      const mockCallback: CallbackNode = {
+        name: 'descriptive_callback',
+        type: 'before_tool',
+        code: 'def callback(ctx): pass',
+        description: 'This callback logs tool execution'
+      };
+      
+      component.selectCallback(mockCallback);
+      
+      expect(component.editingCallback?.description).toBe('This callback logs tool execution');
+    });
+  });
+
+  describe('Callback Type Validation', () => {
+    it('should have all ADK callback types available', () => {
+      const expectedTypes = [
+        'before_agent',
+        'after_agent',
+        'before_model',
+        'after_model',
+        'before_tool',
+        'after_tool'
+      ];
+      
+      expect(component.callbackTypes).toEqual(expectedTypes);
+    });
+  });
+
+  describe('Agent Config with Callbacks', () => {
+    it('should initialize agentConfig with empty callbacks array', () => {
+      expect(component.agentConfig?.callbacks).toEqual([]);
+    });
+
+    it('should update agent callbacks when service emits update', () => {
+      const callbacksSubject = new BehaviorSubject<{ agentName: string, callbacks: CallbackNode[] } | undefined>(undefined);
+      mockAgentBuilderService.getAgentCallbacks.and.returnValue(callbacksSubject);
+      
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      component.agentConfig = {
+        name: 'test-agent',
+        isRoot: false,
+        agent_class: 'LlmAgent',
+        model: 'gemini-2.5-flash',
+        instruction: 'test instruction',
+        sub_agents: [],
+        tools: [],
+        callbacks: []
+      };
+      
+      const newCallbacks: CallbackNode[] = [
+        { name: 'callback1', type: 'before_agent', code: 'def cb1(ctx): pass' },
+        { name: 'callback2', type: 'after_model', code: 'def cb2(ctx): pass' }
+      ];
+      
+      callbacksSubject.next({ agentName: 'test-agent', callbacks: newCallbacks });
+      
+      expect(component.agentConfig.callbacks?.length).toBe(2);
+      expect(component.agentConfig.callbacks).toEqual(newCallbacks);
+      expect(mockChangeDetectorRef.detectChanges).toHaveBeenCalled();
+    });
+
+    it('should not update callbacks for different agent', () => {
+      const callbacksSubject = new BehaviorSubject<{ agentName: string, callbacks: CallbackNode[] } | undefined>(undefined);
+      mockAgentBuilderService.getAgentCallbacks.and.returnValue(callbacksSubject);
+      
+      component = new BuilderTabsComponent(mockChangeDetectorRef);
+      component.agentConfig = {
+        name: 'current-agent',
+        isRoot: false,
+        agent_class: 'LlmAgent',
+        model: 'gemini-2.5-flash',
+        instruction: 'test',
+        sub_agents: [],
+        tools: [],
+        callbacks: []
+      };
+      
+      const newCallbacks: CallbackNode[] = [
+        { name: 'callback1', type: 'before_agent', code: 'def cb1(ctx): pass' }
+      ];
+      
+      callbacksSubject.next({ agentName: 'different-agent', callbacks: newCallbacks });
+      
+      expect(component.agentConfig.callbacks?.length).toBe(0);
+    });
+  });
+});

--- a/src/app/components/canvas/canvas.component.html
+++ b/src/app/components/canvas/canvas.component.html
@@ -79,6 +79,29 @@
               </mat-chip-set>
             }
           </div>
+          <div class="callbacks-container">
+            <div class="callbacks-header">
+              Callbacks
+              <button matIconButton class="action-btn add-callback-btn" (click)="addCallback(ctx.node.id); $event.stopPropagation()" matTooltip="Add callback" aria-label="Add callback">
+                <mat-icon>add</mat-icon>
+              </button>
+            </div>
+            @if (ctx.node.data()?.callbacks?.length) {
+              <mat-chip-set>
+                @for (callback of ctx.node.data()?.callbacks; track callback) {
+                  <mat-chip
+                    (click)="selectCallback(callback, ctx.node)"
+                    [class.selected]="callback === selectedCallback">
+                    {{callback.name}}
+                    <span class="callback-type">{{callback.type}}</span>
+                    <button matChipRemove (click)="deleteCallback(ctx.node.data()?.name, callback); $event.stopPropagation()">
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  </mat-chip>
+                }
+              </mat-chip-set>
+            }
+          </div>
           <handle type="target" position="top" />
           <handle type="source" position="bottom" />
         </div>

--- a/src/app/components/canvas/canvas.component.scss
+++ b/src/app/components/canvas/canvas.component.scss
@@ -412,6 +412,54 @@
   justify-content: space-between;;
 }
 
+.callbacks-container {
+  padding: 12px 6px 12px 12px;
+}
+
+.callbacks-header {
+  font-family: "Google Sans";
+  color: rgb(163, 163, 163);
+  margin-bottom: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.callback-type {
+  font-size: 11px;
+  background: rgba(138, 180, 248, 0.2);
+  color: #8ab4f8;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 4px;
+  font-weight: 500;
+}
+
+.add-callback-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+
+  mat-icon {
+    margin: 0;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &:hover {
+    color: #e8eaed;
+    background-color: rgba(138, 180, 248, 0.1);
+    transform: scale(1.1);
+  }
+}
+
 .instruction-title {
   font-family: "Google Sans";
   color: rgb(163, 163, 163);

--- a/src/app/core/models/AgentBuilder.ts
+++ b/src/app/core/models/AgentBuilder.ts
@@ -23,6 +23,7 @@ export interface AgentNode {
     instruction: string;
     sub_agents: AgentNode[];
     tools?: ToolNode[];
+    callbacks?: CallbackNode[];
     config_path?: string;
 }
 
@@ -38,6 +39,13 @@ export interface ToolArg {
   value: any;
 }
 
+export interface CallbackNode {
+    name: string;
+    type: 'before_agent' | 'after_agent' | 'before_model' | 'after_model' | 'before_tool' | 'after_tool';
+    code: string;
+    description?: string;
+}
+
 export interface YamlConfig {
   name: string;
   model: string;
@@ -46,6 +54,7 @@ export interface YamlConfig {
   instruction: string;
   sub_agents: any;
   tools: any[];
+  callbacks?: any[];
 }
 
 export interface DiagramNode {

--- a/src/app/core/services/agent-builder.service.spec.ts
+++ b/src/app/core/services/agent-builder.service.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { AgentBuilderService } from './agent-builder.service';
+import { AgentNode, CallbackNode } from '../models/AgentBuilder';
+
+describe('AgentBuilderService - Callback Management', () => {
+  let service: AgentBuilderService;
+  let mockAgentNode: AgentNode;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AgentBuilderService);
+
+    mockAgentNode = {
+      name: 'test-agent',
+      isRoot: true,
+      agent_class: 'LlmAgent',
+      model: 'gemini-2.5-flash',
+      instruction: 'Test instruction',
+      sub_agents: [],
+      tools: [],
+      callbacks: []
+    };
+
+    service.addNode(mockAgentNode);
+  });
+
+  afterEach(() => {
+    service.clear();
+  });
+
+  describe('addCallback', () => {
+    it('should add a callback to an agent', () => {
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None',
+        description: 'Test callback'
+      };
+
+      const result = service.addCallback('test-agent', callback);
+
+      expect(result.success).toBe(true);
+      const agent = service.getNode('test-agent');
+      expect(agent?.callbacks).toContain(callback);
+      expect(agent?.callbacks?.length).toBe(1);
+    });
+
+    it('should handle adding callbacks to non-existent agent', () => {
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      const result = service.addCallback('non-existent', callback);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Agent not found');
+      
+      const agent = service.getNode('non-existent');
+      expect(agent).toBeUndefined();
+    });
+
+    it('should initialize callbacks array if undefined', () => {
+      // Remove callbacks array
+      const agent = service.getNode('test-agent');
+      if (agent) {
+        agent.callbacks = undefined;
+      }
+
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      const result = service.addCallback('test-agent', callback);
+
+      expect(result.success).toBe(true);
+      const updatedAgent = service.getNode('test-agent');
+      expect(updatedAgent?.callbacks).toBeDefined();
+      expect(updatedAgent?.callbacks?.length).toBe(1);
+    });
+
+    it('should emit callback update', () => {
+      spyOn(service['agentCallbacksSubject'], 'next');
+
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      const result = service.addCallback('test-agent', callback);
+
+      expect(result.success).toBe(true);
+      expect(service['agentCallbacksSubject'].next).toHaveBeenCalledWith({
+        agentName: 'test-agent',
+        callbacks: [callback]
+      });
+    });
+
+    it('should reject duplicate callback names', () => {
+      const callback1: CallbackNode = {
+        name: 'duplicate_callback',
+        type: 'before_agent',
+        code: 'def duplicate_callback(ctx): pass'
+      };
+
+      const callback2: CallbackNode = {
+        name: 'duplicate_callback',
+        type: 'after_agent',
+        code: 'def duplicate_callback(ctx): pass'
+      };
+
+      const result1 = service.addCallback('test-agent', callback1);
+      expect(result1.success).toBe(true);
+
+      const result2 = service.addCallback('test-agent', callback2);
+      expect(result2.success).toBe(false);
+      expect(result2.error).toContain('already exists');
+    });
+
+    it('should validate callback name format', () => {
+      const invalidCallbacks = [
+        { name: '123invalid', type: 'before_agent' as const, code: 'def test(): pass' },
+        { name: 'invalid-name', type: 'before_agent' as const, code: 'def test(): pass' },
+        { name: 'invalid name', type: 'before_agent' as const, code: 'def test(): pass' },
+        { name: '', type: 'before_agent' as const, code: 'def test(): pass' }
+      ];
+
+      invalidCallbacks.forEach(callback => {
+        const result = service.addCallback('test-agent', callback);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('valid Python identifier');
+      });
+
+      const validCallbacks = [
+        { name: 'valid_callback', type: 'before_agent' as const, code: 'def test(): pass' },
+        { name: '_private_callback', type: 'before_agent' as const, code: 'def test(): pass' },
+        { name: 'callback123', type: 'before_agent' as const, code: 'def test(): pass' }
+      ];
+
+      validCallbacks.forEach(callback => {
+        const result = service.addCallback('test-agent', callback);
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it('should validate callback code is not empty', () => {
+      const emptyCodeCallbacks = [
+        { name: 'empty_code', type: 'before_agent' as const, code: '' },
+        { name: 'whitespace_code', type: 'before_agent' as const, code: '   ' }
+      ];
+
+      emptyCodeCallbacks.forEach(callback => {
+        const result = service.addCallback('test-agent', callback);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('cannot be empty');
+      });
+    });
+  });
+
+  describe('deleteCallback', () => {
+    let callback: CallbackNode;
+
+    beforeEach(() => {
+      callback = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+      service.addCallback('test-agent', callback);
+    });
+
+    it('should delete a callback from an agent', () => {
+      const result = service.deleteCallback('test-agent', callback);
+
+      expect(result.success).toBe(true);
+      const agent = service.getNode('test-agent');
+      expect(agent?.callbacks).not.toContain(callback);
+      expect(agent?.callbacks?.length).toBe(0);
+    });
+
+    it('should handle deleting from non-existent agent', () => {
+      expect(() => service.deleteCallback('non-existent', callback)).not.toThrow();
+    });
+
+    it('should emit callback update after deletion', () => {
+      spyOn(service['agentCallbacksSubject'], 'next');
+
+      service.deleteCallback('test-agent', callback);
+
+      expect(service['agentCallbacksSubject'].next).toHaveBeenCalledWith({
+        agentName: 'test-agent',
+        callbacks: []
+      });
+    });
+
+    it('should clear selected callback if deleted', () => {
+      service.setSelectedCallback(callback);
+      
+      service.deleteCallback('test-agent', callback);
+
+      service.getSelectedCallback().subscribe(selectedCallback => {
+        expect(selectedCallback).toBeUndefined();
+      });
+    });
+  });
+
+  describe('callback selection', () => {
+    it('should get and set selected callback', () => {
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      service.setSelectedCallback(callback);
+
+      service.getSelectedCallback().subscribe(selectedCallback => {
+        expect(selectedCallback).toBe(callback);
+      });
+    });
+
+    it('should clear selected callback', () => {
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      service.setSelectedCallback(callback);
+      service.setSelectedCallback(undefined);
+
+      service.getSelectedCallback().subscribe(selectedCallback => {
+        expect(selectedCallback).toBeUndefined();
+      });
+    });
+  });
+
+  describe('getAgentCallbacks', () => {
+    it('should emit callback updates', () => {
+      const callback: CallbackNode = {
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      };
+
+      let emittedValue: any;
+      service.getAgentCallbacks().subscribe(value => {
+        emittedValue = value;
+      });
+
+      service.addCallback('test-agent', callback);
+
+      expect(emittedValue).toEqual({
+        agentName: 'test-agent',
+        callbacks: [callback]
+      });
+    });
+  });
+
+  describe('setAgentCallbacks', () => {
+    it('should set callbacks with agent name and callbacks', () => {
+      const callbacks: CallbackNode[] = [{
+        name: 'test_callback',
+        type: 'before_agent',
+        code: 'def test_callback(callback_context): return None'
+      }];
+
+      let emittedValue: any;
+      service.getAgentCallbacks().subscribe(value => {
+        emittedValue = value;
+      });
+
+      service.setAgentCallbacks('test-agent', callbacks);
+
+      expect(emittedValue).toEqual({
+        agentName: 'test-agent',
+        callbacks: callbacks
+      });
+    });
+
+    it('should clear callbacks when called without parameters', () => {
+      let emittedValue: any;
+      service.getAgentCallbacks().subscribe(value => {
+        emittedValue = value;
+      });
+
+      service.setAgentCallbacks();
+
+      expect(emittedValue).toBeUndefined();
+    });
+  });
+});

--- a/src/app/core/services/agent-builder.service.ts
+++ b/src/app/core/services/agent-builder.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, BehaviorSubject } from 'rxjs';
-import { AgentNode, ToolNode } from '../models/AgentBuilder';
+import { AgentNode, ToolNode, CallbackNode } from '../models/AgentBuilder';
 
 @Injectable({
   providedIn: 'root'
@@ -10,8 +10,10 @@ export class AgentBuilderService {
 
   private selectedToolSubject = new BehaviorSubject<any | undefined>(undefined);
   private selectedNodeSubject = new BehaviorSubject<AgentNode|undefined>(undefined);
+  private selectedCallbackSubject = new BehaviorSubject<CallbackNode|undefined>(undefined);
   private loadedAgentDataSubject = new BehaviorSubject<string|undefined>(undefined);
   private agentToolsSubject = new BehaviorSubject<{ agentName: string, tools: ToolNode[] } | undefined>(undefined);
+  private agentCallbacksSubject = new BehaviorSubject<{ agentName: string, callbacks: CallbackNode[] } | undefined>(undefined);
 
   constructor() { }
 
@@ -49,7 +51,9 @@ export class AgentBuilderService {
     this.nodes = [];
     this.setSelectedNode(undefined);
     this.setSelectedTool(undefined);
+    this.setSelectedCallback(undefined);
     this.setAgentTools();
+    this.setAgentCallbacks();
   }
 
   getSelectedNode(): Observable<AgentNode|undefined> {
@@ -66,6 +70,14 @@ export class AgentBuilderService {
 
   setSelectedTool(tool: ToolNode | undefined) {
     this.selectedToolSubject.next(tool);
+  }
+
+  getSelectedCallback(): Observable<CallbackNode|undefined> {
+    return this.selectedCallbackSubject.asObservable();
+  }
+
+  setSelectedCallback(callback: CallbackNode | undefined) {
+    this.selectedCallbackSubject.next(callback);
   }
 
   addTool(agentName: string, tool: ToolNode) {
@@ -90,6 +102,72 @@ export class AgentBuilderService {
     }
   }
 
+  addCallback(agentName: string, callback: CallbackNode): { success: boolean, error?: string } {
+    try {
+      const agentNode = this.getNode(agentName);
+      if (!agentNode) {
+        return { success: false, error: 'Agent not found' };
+      }
+      
+      if (!agentNode.callbacks) {
+        agentNode.callbacks = [];
+      }
+      
+      // Check for duplicate callback names
+      const duplicateCallback = agentNode.callbacks.find(cb => cb.name === callback.name);
+      if (duplicateCallback) {
+        return { success: false, error: `Callback with name '${callback.name}' already exists` };
+      }
+      
+      // Validate callback name (must be valid Python identifier)
+      const pythonIdentifierRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+      if (!pythonIdentifierRegex.test(callback.name)) {
+        return { success: false, error: 'Callback name must be a valid Python identifier' };
+      }
+      
+      // Basic Python code validation
+      if (!callback.code || callback.code.trim().length === 0) {
+        return { success: false, error: 'Callback code cannot be empty' };
+      }
+      
+      agentNode.callbacks.push(callback);
+      this.agentCallbacksSubject.next({ agentName, callbacks: agentNode.callbacks });
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: 'Failed to add callback: ' + (error as Error).message };
+    }
+  }
+
+  deleteCallback(agentName: string, callbackToDelete: CallbackNode): { success: boolean, error?: string } {
+    try {
+      const agentNode = this.getNode(agentName);
+      if (!agentNode) {
+        return { success: false, error: 'Agent not found' };
+      }
+      
+      if (!agentNode.callbacks) {
+        return { success: false, error: 'No callbacks found for this agent' };
+      }
+      
+      const callbackIndex = agentNode.callbacks.findIndex(callback => callback.name === callbackToDelete.name);
+      if (callbackIndex === -1) {
+        return { success: false, error: 'Callback not found' };
+      }
+      
+      agentNode.callbacks.splice(callbackIndex, 1);
+      this.agentCallbacksSubject.next({ agentName, callbacks: agentNode.callbacks });
+      
+      // Clear selection if the deleted callback was selected
+      if (this.selectedCallbackSubject.value?.name === callbackToDelete.name) {
+        this.setSelectedCallback(undefined);
+      }
+      
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: 'Failed to delete callback: ' + (error as Error).message };
+    }
+  }
+
   setLoadedAgentData(agent: string | undefined) {
     this.loadedAgentDataSubject.next(agent);
   }
@@ -107,6 +185,18 @@ export class AgentBuilderService {
       this.agentToolsSubject.next({ agentName, tools });
     } else {
       this.agentToolsSubject.next(undefined);
+    }
+  }
+
+  getAgentCallbacks(): Observable<{ agentName: string, callbacks: CallbackNode[] } | undefined> {
+    return this.agentCallbacksSubject.asObservable();
+  }
+
+  setAgentCallbacks(agentName?: string, callbacks?: CallbackNode[]) {
+    if (agentName && callbacks) {
+      this.agentCallbacksSubject.next({ agentName, callbacks });
+    } else {
+      this.agentCallbacksSubject.next(undefined);
     }
   }
 

--- a/src/utils/yaml-utils.spec.ts
+++ b/src/utils/yaml-utils.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { YamlUtils } from './yaml-utils';
+import { AgentNode, CallbackNode, ToolNode } from '../app/core/models/AgentBuilder';
+import * as YAML from 'yaml';
+
+describe('YamlUtils - Callback Support', () => {
+  let mockAgentNode: AgentNode;
+  let mockFormData: FormData;
+
+  beforeEach(() => {
+    mockFormData = new FormData();
+    
+    mockAgentNode = {
+      name: 'test-agent',
+      isRoot: true,
+      agent_class: 'LlmAgent',
+      model: 'gemini-2.5-flash',
+      instruction: 'Test instruction',
+      sub_agents: [],
+      tools: [{
+        name: '.tool_1',
+        toolType: 'Custom tool',
+        args: []
+      }],
+      callbacks: [{
+        name: 'callback_1',
+        type: 'before_agent',
+        code: 'def callback_function(callback_context):\n    return None',
+        description: 'Test callback'
+      }]
+    };
+  });
+
+  describe('buildCallbacksConfig', () => {
+    it('should build callbacks configuration correctly', () => {
+      const callbacks: CallbackNode[] = [
+        {
+          name: 'before_callback',
+          type: 'before_agent',
+          code: 'def before_callback(ctx): pass',
+          description: 'Before agent callback'
+        },
+        {
+          name: 'after_callback',
+          type: 'after_tool',
+          code: 'def after_callback(ctx): pass'
+        }
+      ];
+
+      const config = YamlUtils.buildCallbacksConfig(callbacks);
+
+      expect(config.length).toBe(2);
+      expect(config[0]).toEqual({
+        name: 'before_callback',
+        type: 'before_agent',
+        code: 'def before_callback(ctx): pass',
+        description: 'Before agent callback'
+      });
+      expect(config[1]).toEqual({
+        name: 'after_callback',
+        type: 'after_tool',
+        code: 'def after_callback(ctx): pass'
+      });
+    });
+
+    it('should return empty array for undefined callbacks', () => {
+      const config = YamlUtils.buildCallbacksConfig(undefined);
+      expect(config).toEqual([]);
+    });
+
+    it('should return empty array for empty callbacks array', () => {
+      const config = YamlUtils.buildCallbacksConfig([]);
+      expect(config).toEqual([]);
+    });
+
+    it('should handle callbacks without description', () => {
+      const callbacks: CallbackNode[] = [
+        {
+          name: 'simple_callback',
+          type: 'before_model',
+          code: 'def simple_callback(ctx): pass'
+        }
+      ];
+
+      const config = YamlUtils.buildCallbacksConfig(callbacks);
+
+      expect(config.length).toBe(1);
+      expect(config[0]).toEqual({
+        name: 'simple_callback',
+        type: 'before_model',
+        code: 'def simple_callback(ctx): pass'
+      });
+      expect(config[0].description).toBeUndefined();
+    });
+  });
+
+  describe('generateYamlFile', () => {
+    it('should generate YAML file with callbacks when agent has callbacks', () => {
+      // Test the YAML generation logic by creating a mock YAML config
+      const callbacksConfig = YamlUtils.buildCallbacksConfig(mockAgentNode.callbacks);
+      
+      expect(callbacksConfig.length).toBe(1);
+      expect(callbacksConfig[0]).toEqual({
+        name: 'callback_1',
+        type: 'before_agent',
+        code: 'def callback_function(callback_context):\n    return None',
+        description: 'Test callback'
+      });
+
+      // Verify that generateYamlFile creates a FormData entry
+      YamlUtils.generateYamlFile(mockAgentNode, mockFormData, 'test-app');
+      
+      expect(mockFormData.getAll('files').length).toBe(1);
+      const file = mockFormData.get('files') as File;
+      expect(file).toBeTruthy();
+      expect(file.name).toBe('test-app/root_agent.yaml');
+    });
+
+    it('should not include callbacks in YAML when agent has no callbacks', () => {
+      mockAgentNode.callbacks = undefined;
+      const callbacksConfig = YamlUtils.buildCallbacksConfig(mockAgentNode.callbacks);
+      
+      expect(callbacksConfig).toEqual([]);
+    });
+
+    it('should handle empty callbacks array', () => {
+      mockAgentNode.callbacks = [];
+      const callbacksConfig = YamlUtils.buildCallbacksConfig(mockAgentNode.callbacks);
+      
+      expect(callbacksConfig).toEqual([]);
+    });
+  });
+});

--- a/src/utils/yaml-utils.ts
+++ b/src/utils/yaml-utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AgentNode, ToolNode, YamlConfig  } from "../app/core/models/AgentBuilder";
+import { AgentNode, ToolNode, CallbackNode, YamlConfig  } from "../app/core/models/AgentBuilder";
 import * as YAML from 'yaml';
 
 export class YamlUtils {
@@ -34,6 +34,12 @@ export class YamlUtils {
       instruction: agentNode.instruction,
       sub_agents: subAgents,
       tools: this.buildToolsConfig(agentNode.tools)
+    }
+
+    // Add callbacks if they exist
+    const callbacksConfig = this.buildCallbacksConfig(agentNode.callbacks);
+    if (callbacksConfig.length > 0) {
+      yamlConfig.callbacks = callbacksConfig;
     }
 
     const yamlString = YAML.stringify(yamlConfig);
@@ -83,5 +89,18 @@ export class YamlUtils {
 
       return config;
     });
+  }
+
+  static buildCallbacksConfig(callbacks: CallbackNode[] | undefined): any[] {
+    if (!callbacks || callbacks.length === 0) {
+      return [];
+    }
+
+    return callbacks.map(callback => ({
+      name: callback.name,
+      type: callback.type,
+      code: callback.code,
+      ...(callback.description && { description: callback.description })
+    }));
   }
 }


### PR DESCRIPTION
#### Overview
This pull request introduces a complete callback management feature to the ADK Web UI's Visual Builder. This allows users to add, edit, and delete callbacks for an agent, just as they do with tools. It supports all six ADK callback types: `before_agent`, `after_agent`, `before_model`, `after_model`, `before_tool`, and `after_tool`.

#### Changes
For this implementation, we first extended the data model by adding a new `CallbackNode` interface to hold a callback's name, type, code, and description.

In the service layer, the `AgentBuilderService` has been extended with methods for adding and deleting callbacks, managing their selection state, and performing reactive state updates using Observables.

On the UI side, a new "Callbacks" tab has been added to the builder. On the canvas, configured callbacks are displayed as chips, and users can directly input and edit their Python code via a dedicated form. Additionally, `yaml-utils` has been updated to ensure that callback information is included in the generated YAML file.

As part of our quality improvement efforts, we have added comprehensive error handling that displays user-friendly messages. We have also introduced robust validation, including checks for the uniqueness of callback names within an agent, validation of names as valid Python identifiers, and ensuring the code field is not empty.

To enhance type safety across the codebase, TypeScript type definitions and interfaces have been refined. Furthermore, unit tests have been expanded to cover a wide range of scenarios, including not only happy-path operations but also error cases, validation rules, and state updates via Observables.

#### Testing
- Confirmed that TypeScript compiles successfully.
- Verified that all unit tests for the callback feature are passing.
- Completed manual testing for all callback operations.
- Confirmed that YAML files containing callbacks are generated correctly.

### test captures
<img width="1920" height="885" alt="test_capture_1" src="https://github.com/user-attachments/assets/cb2d361f-7bfb-49b5-a7ba-ce6907f082c5" />
<img width="1187" height="698" alt="test_capture_2" src="https://github.com/user-attachments/assets/987d46fa-b995-4b17-ad35-f1a82daab319" />

