### PR TITLE
feat: preserve canvas layout and update sub-agent UI

### DIFF
--- a/src/app/components/canvas/canvas.component.html
+++ b/src/app/components/canvas/canvas.component.html
@@ -60,6 +60,9 @@
             <div class="node-title">
               <span class="material-symbols-outlined" style="margin-right: 5px;">robot_2</span>
               {{ctx.node.data()?.name || 'root_agent'}}
+              @if (isRootAgent(ctx.node.data()?.name)) {
+                <span class="node-badge">Root</span>
+              }
             </div>
             <div class="action-button-bar">
               @if (!isRootAgentForCurrentTab(ctx.node.data()?.name)) {
@@ -71,12 +74,6 @@
             </div>
           </div>
           <div class="tools-container">
-            <div class="tools-header">
-              Tools
-              <button matIconButton class="action-btn add-tool-btn" (click)="addTool(ctx.node.id); $event.stopPropagation()" matTooltip="Add tool" aria-label="Add tool">
-                <mat-icon>add</mat-icon>
-              </button>
-            </div>
             @if (toolsMap$ | async; as toolsMap) {
               @if (ctx.node.data) {
                 @if (toolsMap.get(ctx.node.data().name); as tools) {
@@ -101,49 +98,51 @@
               }
             }
           </div>
-          <div class="add-subagent-container">
-            <button
-              matIconButton
-              class="add-subagent-btn"
-              [matMenuTriggerFor]="agentMenu"
-              #agentMenuTrigger="matMenuTrigger"
-              matTooltip="Add sub-agent"
-              aria-label="Add sub-agent"
-              (click)="$event.stopPropagation()"
-            >
-              <span class="add-subagent-symbol">+</span>
-            </button>
-          </div>
-          <mat-menu #agentMenu="matMenu">
-            <button
-              mat-menu-item
-              (click)="handleAgentTypeSelection('LlmAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
-            >
-              <mat-icon>psychology</mat-icon>
-              <span>LLM Agent</span>
-            </button>
-            <button
-              mat-menu-item
-              (click)="handleAgentTypeSelection('SequentialAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
-            >
-              <mat-icon>more_horiz</mat-icon>
-              <span>Sequential Agent</span>
-            </button>
-            <button
-              mat-menu-item
-              (click)="handleAgentTypeSelection('LoopAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
-            >
-              <mat-icon>sync</mat-icon>
-              <span>Loop Agent</span>
-            </button>
-            <button
-              mat-menu-item
-              (click)="handleAgentTypeSelection('ParallelAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
-            >
-              <mat-icon>density_medium</mat-icon>
-              <span>Parallel Agent</span>
-            </button>
-          </mat-menu>
+          @if (isNodeSelected(ctx.node)) {
+            <div class="add-subagent-container">
+              <button
+                matIconButton
+                class="add-subagent-btn"
+                [matMenuTriggerFor]="agentMenu"
+                #agentMenuTrigger="matMenuTrigger"
+                matTooltip="Add sub-agent"
+                aria-label="Add sub-agent"
+                (click)="$event.stopPropagation()"
+              >
+                <span class="add-subagent-symbol">+</span>
+              </button>
+              <mat-menu #agentMenu="matMenu">
+                <button
+                  mat-menu-item
+                  (click)="handleAgentTypeSelection('LlmAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
+                >
+                  <mat-icon>psychology</mat-icon>
+                  <span>LLM Agent</span>
+                </button>
+                <button
+                  mat-menu-item
+                  (click)="handleAgentTypeSelection('SequentialAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
+                >
+                  <mat-icon>more_horiz</mat-icon>
+                  <span>Sequential Agent</span>
+                </button>
+                <button
+                  mat-menu-item
+                  (click)="handleAgentTypeSelection('LoopAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
+                >
+                  <mat-icon>sync</mat-icon>
+                  <span>Loop Agent</span>
+                </button>
+                <button
+                  mat-menu-item
+                  (click)="handleAgentTypeSelection('ParallelAgent', ctx.node.data()?.name, agentMenuTrigger, $event)"
+                >
+                  <mat-icon>density_medium</mat-icon>
+                  <span>Parallel Agent</span>
+                </button>
+              </mat-menu>
+            </div>
+          }
           <handle type="target" position="top" />
           <handle type="source" position="bottom" />
         </div>

--- a/src/app/components/canvas/canvas.component.scss
+++ b/src/app/components/canvas/canvas.component.scss
@@ -500,6 +500,18 @@
     font-weight: 500;
 }
 
+.node-badge {
+    margin-left: 8px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(0, 187, 234, 0.2), rgba(0, 78, 122, 0.4));
+    color: #00BBEA;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
 .tools-container {
     padding: 12px 6px 12px 12px;
 }
@@ -686,7 +698,7 @@ mat-chip {
 .add-subagent-container {
     position: absolute;
     left: 50%;
-    bottom: -58px;
+    bottom: -68px;
     transform: translateX(-50%);
     display: flex;
     justify-content: center;

--- a/src/app/components/canvas/canvas.component.ts
+++ b/src/app/components/canvas/canvas.component.ts
@@ -322,7 +322,7 @@ export class CanvasComponent implements AfterViewInit, OnInit, OnChanges {
       id: newAgentName,
       point: signal({
         x: parentNode.point().x + subAgentIndex * 400,
-        y: parentNode.point().y + 210, // Position below the parent with spacing
+        y: parentNode.point().y + 300, // Position below the parent with spacing
       }),
       type: "html-template",
       data: signal(agentNodeData),


### PR DESCRIPTION
- feat: preserve canvas layout and update sub-agent UI (66d3e1e, 2bb492c)
Capture node coordinates before every board reload and reapply them when switching between tool boards or reloading YAML so the layout stays stable. The floating add-sub-agent button now sits 10px further below the card, shows a “Root” badge on the main agent, and renders only while a node is selected.

- b/448639224 – Clicking the canvas should deselect nodes (d9938bf)
Added a canvas click handler that clears the current selection unless the click occurs on an interactive control, matching expected deselect behaviour.
- 
- b/448472142 – Change agent card styles (4aecef0)
Updated the agent card styling: simplified the card header, refactored borders/backgrounds, introduced the floating add button concept, and aligned the cards with the latest visual spec.